### PR TITLE
Log i18n key misses per language file

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 
 npx lint-staged
+yarn scan-i18n

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "test": "jest",
     "test:watch": "jest --watch --detectOpenHandles",
     "generate-types": "typechain --target ethers-v5 src/artifacts/*.json && prettier --write \"types/ethers-contracts/**/*.ts\"",
-    "postinstall": "yarn generate-types"
+    "postinstall": "yarn generate-types",
+    "scan-i18n": "node scan_i18n.js ./src ./public/locales"
   },
   "eslintConfig": {
     "extends": [

--- a/scan_i18n.js
+++ b/scan_i18n.js
@@ -1,0 +1,89 @@
+const fs = require('fs');
+const path = require('path');
+
+// reads the arguments at the command line:
+// index 2 is the source code directory
+// index 3 is the language directory
+// iterates over the source directory, recursively, to find any call to t('YOUR_KEY_HERE')
+// once all keys have been found, it iterates over the langage directory and checks each translation file to see if it has the i18n keys expected
+// if any don't, then they are noted
+// after iterating over all language files, the resulting misses are printed to the command line
+// but if everything is translated, then it prints a success message instead.
+
+if (process.argv.length !== 4) {
+  console.error(
+    `unexpected arguments; expected 2, saw ${process.argv.length - 2}`,
+  );
+  return;
+}
+console.log(
+  'scanning internationalization keys in',
+  process.argv[2],
+  'against language files in',
+  process.argv[3],
+);
+
+function getAllFiles(dirPath, fileArray) {
+  fs.readdirSync(dirPath).forEach(function (file) {
+    let filePath = path.join(dirPath, file);
+    let stat = fs.statSync(filePath);
+    if (stat.isDirectory()) {
+      getAllFiles(filePath, fileArray);
+    } else {
+      fileArray.push(filePath);
+    }
+  });
+  return fileArray;
+}
+
+const fileArray = getAllFiles(process.argv[2], []);
+const languageFiles = getAllFiles(process.argv[3], []);
+
+const regex = /(\s|\{)t\(\'(\w*)\'/;
+const keys = [];
+const rejects = [];
+fileArray.forEach((filePath) => {
+  const fileContents = fs.readFileSync(filePath, {
+    encoding: 'utf-8',
+    flag: 'r',
+  });
+  fileContents.split('\n').forEach((textLine) => {
+    const result = regex.exec(textLine);
+    if (result) {
+      keys.push(result[2]);
+    }
+  });
+});
+
+// now reduce to uniques
+const uniqueKeys = [...new Set(keys)];
+const missTracker = {};
+
+// and now we can check our translations for these keys
+languageFiles.forEach((filePath) => {
+  const fileContents = fs.readFileSync(filePath, {
+    encoding: 'utf-8',
+    flag: 'r',
+  });
+  // turn that filecontent back into an object and get its keys
+  const contentObject = JSON.parse(fileContents);
+  uniqueKeys.forEach((key) => {
+    if (!contentObject[key]) {
+      if (!missTracker[filePath]) {
+        missTracker[filePath] = [];
+      }
+      missTracker[filePath].push(key);
+    }
+  });
+});
+
+if (Object.keys(missTracker).length > 0) {
+  Object.keys(missTracker).forEach((fileName) => {
+    // red: \x1b[31m%s\x1b[0m
+    // yellow: \x1b[33m%s\x1b[0m
+    console.error('\x1b[31m%s\x1b[0m', `Missing keys in ./${fileName}:`);
+    console.log('\x1b[33m%s\x1b[0m', `[${missTracker[fileName].join(', ')}]\n`);
+  });
+} else {
+  console.log('Success! i18n scan found no missing keys');
+}


### PR DESCRIPTION
scan_i18n.js will iterate over the source files in a given directory to
find any references to the i18n call "t('KEY')" and make a list of
unique keys from the source. It then checks all language files against
that, and notes any misses from the list of in use keys at the end of
its run.

### What does it do?
Creates the utility js file scan_i18n.js that will iterate over all source files in the repo to find the `t('KEY')` pattern and isolate keys, reduce them to a unique list, and then iterate over each language file and note any keys which are not in those files, resulting in a print to the command line of files and their missing keys or a success message. I also created a yarn script to run this as configured for our repo and a husky precommit to call that yarn script.

### Any helpful background information?
The need for such a script/utility/package was brought up on the website call today.

### Any new dependencies? Why were they added?
No. This was created to avoid bringing in an external package. Tradeoff: it may be frail or not quite properly tuned (with the regex, for example) which is why I am creating this as a draft

### Relevant screenshots/gifs
![image](https://user-images.githubusercontent.com/4706001/135566054-ab2746c9-20d1-40f9-bace-709f562d80b2.png)

### Does it close any issues?
No. Unless I/someone else opens one before I make this a real PR
