### PR TITLE
chore(missing-translations): make locale single select

### DIFF
--- a/.github/ISSUE_TEMPLATE/missing-translations.yml
+++ b/.github/ISSUE_TEMPLATE/missing-translations.yml
@@ -22,7 +22,7 @@ body:
     id: 'missing-locales'
     attributes:
       label: 'List of missing locales'
-      multiple: true
+      multiple: false
       description: 'Check the locales that are missing translations'
       options:
         - 'de'


### PR DESCRIPTION
This PR changes the "locale" field of the "missing translations" issue form to be single-select rather than multi-select.