### PR TITLE
Fix couple misused characters in zh-TW

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ yarn-debug.log*
 yarn-error.log*
 
 .next
+
+# editors
+.idea

--- a/public/locales/zh-TW/common.json
+++ b/public/locales/zh-TW/common.json
@@ -21,7 +21,7 @@
   "enterDeveloperId": "請輸入$t(title)編號",
   "hosting": "托管於:",
   "copyLinkToNFT": "複製 NFT 鏈接",
-  "linkCopied": "鏈接已複製到剪貼板",
+  "linkCopied": "鏈接已複製",
   "projectsList": "$t(title) 創建的$t(community)$t(projects)列表",
   "ddaoTokenSearch": "DDAO 代幣搜索",
   "by": "作者:",

--- a/public/locales/zh-TW/common.json
+++ b/public/locales/zh-TW/common.json
@@ -24,7 +24,7 @@
   "linkCopied": "鏈接已複製",
   "projectsList": "$t(title) 創建的$t(community)$t(projects)列表",
   "ddaoTokenSearch": "DDAO 代幣搜索",
-  "by": "作者:",
+  "by": "作者：",
   "otherTokensOwnedByThisAddress":"此 address 拥有的其他代币",
   "noOtherTokens":"此 address 没有其他代币"
 }

--- a/public/locales/zh-TW/common.json
+++ b/public/locales/zh-TW/common.json
@@ -26,5 +26,5 @@
   "ddaoTokenSearch": "DDAO 代幣搜索",
   "by": "作者：",
   "otherTokensOwnedByThisAddress":"此 address 拥有的其他代币",
-  "noOtherTokens":"此 address 没有其他代币"
+  "noOtherTokens":"此 address 没有其他代幣"
 }

--- a/public/locales/zh-TW/common.json
+++ b/public/locales/zh-TW/common.json
@@ -17,7 +17,7 @@
   "daoGithubOrg": "$t(title) GitHub $t(organization)",
   "daoGithubRepo": "$t(title) GitHub $t(repository)",
   "owner": "擁有者",
-  "unclaimed": "尚未被持有",
+  "unclaimed": "尚未被擁有",
   "enterDeveloperId": "請輸入$t(title)編號",
   "hosting": "托管於:",
   "copyLinkToNFT": "複製NFT鏈接",

--- a/public/locales/zh-TW/common.json
+++ b/public/locales/zh-TW/common.json
@@ -26,5 +26,5 @@
   "ddaoTokenSearch": "DDAO 代幣搜索",
   "by": "作者：",
   "otherTokensOwnedByThisAddress":"此地址擁有的其他代幣",
-  "noOtherTokens":"此 address 没有其他代幣"
+  "noOtherTokens":"此地址没有其他代幣"
 }

--- a/public/locales/zh-TW/common.json
+++ b/public/locales/zh-TW/common.json
@@ -3,7 +3,7 @@
   "home": "首頁",
   "projects": "專案",
   "searchId": "搜尋$t(title)編號",
-  "description": "相信 網絡集體所有權 的開發者$t(community)",
+  "description": "一個相信網絡共享所有權的開發者 $t(community)",
   "loading": "載入中...",
   "error": "錯誤",
   "viewNftOpenSea": "在 OpenSea 上查看 NFT",

--- a/public/locales/zh-TW/common.json
+++ b/public/locales/zh-TW/common.json
@@ -25,6 +25,6 @@
   "projectsList": "$t(title) 創建的$t(community)$t(projects)列表",
   "ddaoTokenSearch": "DDAO 代幣搜索",
   "by": "作者：",
-  "otherTokensOwnedByThisAddress":"此 address 拥有的其他代币",
+  "otherTokensOwnedByThisAddress":"此地址擁有的其他代幣",
   "noOtherTokens":"此 address 没有其他代幣"
 }

--- a/public/locales/zh-TW/common.json
+++ b/public/locales/zh-TW/common.json
@@ -20,7 +20,7 @@
   "unclaimed": "尚未被擁有",
   "enterDeveloperId": "請輸入$t(title)編號",
   "hosting": "托管於:",
-  "copyLinkToNFT": "複製NFT鏈接",
+  "copyLinkToNFT": "複製 NFT 鏈接",
   "linkCopied": "鏈接已複製到剪貼板",
   "projectsList": "$t(title) 創建的$t(community)$t(projects)列表",
   "ddaoTokenSearch": "DDAO 代幣搜索",

--- a/public/locales/zh-TW/common.json
+++ b/public/locales/zh-TW/common.json
@@ -10,7 +10,7 @@
   "viewOwnerEtherscan": "在 Etherscan 上查看擁有者",
   "developerTraits": "開發者特征 (traits)",
   "failedLoadTraits": "無法載入開發者特征 (traits)",
-  "madeBy": "由$t(title)所創建:",
+  "madeBy": "由$t(title)所創建：",
   "organization": "組織",
   "repository": "Repository",
   "community": "社群",

--- a/public/locales/zh-TW/common.json
+++ b/public/locales/zh-TW/common.json
@@ -1,5 +1,5 @@
 {
-  "title": "開發者DAO",
+  "title": "開發者 DAO",
   "home": "首頁",
   "projects": "專案",
   "searchId": "搜尋$t(title)編號",

--- a/public/locales/zh-TW/common.json
+++ b/public/locales/zh-TW/common.json
@@ -4,7 +4,7 @@
   "projects": "專案",
   "searchId": "搜尋$t(title)編號",
   "description": "一個相信網絡共享所有權的開發者 $t(community)",
-  "loading": "載入中...",
+  "loading": "下載中...",
   "error": "錯誤",
   "viewNftOpenSea": "在 OpenSea 上查看 NFT",
   "viewOwnerEtherscan": "在 Etherscan 上查看擁有者",

--- a/public/locales/zh-TW/common.json
+++ b/public/locales/zh-TW/common.json
@@ -1,7 +1,7 @@
 {
   "title": "開發者 DAO",
   "home": "首頁",
-  "projects": "專案",
+  "projects": "項目",
   "searchId": "搜尋$t(title)編號",
   "description": "一個相信網絡共享所有權的開發者 $t(community)",
   "loading": "下載中...",

--- a/public/locales/zh-TW/common.json
+++ b/public/locales/zh-TW/common.json
@@ -18,7 +18,7 @@
   "daoGithubRepo": "$t(title) GitHub $t(repository)",
   "owner": "擁有者",
   "unclaimed": "尚未被持有",
-  "enterDeveloperId": "请輸入$t(title)編號",
+  "enterDeveloperId": "請輸入$t(title)編號",
   "hosting": "托管於:",
   "copyLinkToNFT": "複製NFT鏈接",
   "linkCopied": "鏈接已複製到剪貼板",


### PR DESCRIPTION
### What does it do?

Fix typos and some misused characters

### Any helpful background information?

- The first version of translation has many simplified Chinese characters, this is due to many online translators/translating engine nowadays having difficulty to use decent "transitional Chinese"
- I am native Taiwanese who can correct them

### Any new dependencies? Why were they added?

ignore `.idea` file, IntelliJ is a popular editors and we should ignore `.idea`(the IntelliJ confirmation file) if possible

### Relevant screenshots/gifs

### Does it close any issues?

No issue 
