### PR TITLE
chore: run prettier after generating types

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "type-check": "tsc --noEmit",
     "test": "jest",
     "test:watch": "jest --watch --detectOpenHandles",
-    "generate-types": "typechain --target ethers-v5 src/artifacts/*.json",
+    "generate-types": "typechain --target ethers-v5 src/artifacts/*.json && prettier --write \"types/ethers-contracts/**/*.ts\"",
     "postinstall": "yarn generate-types"
   },
   "eslintConfig": {


### PR DESCRIPTION
This PR modifies the `generate-types` script to run `prettier` on the generated type files in `types/ethers-contracts`. 

This change resolves an issue where running `yarn` caused types to be generated that weren't formatted with `prettier`, so we ended up with unstaged changes to those files where the changes were purely the missing formatting.