### PR TITLE
Add missing description for English metadata

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,5 +1,6 @@
 {
   "title": "Developer DAO",
+  "description": "A community of builders who believe in collective ownership of the internet.",
   "currentStatus": "Current Status",
   "season": "Season",
   "callout": "We're forming guilds, creating culture, strengthening our community, teaching & learning, and building cool shit together.",


### PR DESCRIPTION
### What does it do?
This PR adds the description property with the value "A community of builders who believe in collective ownership of the internet." which is currently missing in the file `public/locales/en/common.json`.

### Any helpful background information?
This adds a useful description in the link preview when sharing the developerdao.com link in places like Discord and Twitter.

### Relevant screenshots/gifs
![DDAO_metadata_update](https://user-images.githubusercontent.com/42661870/147998868-3993470d-83b3-4e95-a18f-7854f8d43a38.png)

### Any new dependencies? Why were they added?
N/A

### Does it close any issues?
N/A

