### PR TITLE
Update membership info based off the notion details

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -35,7 +35,7 @@
   },
   "membership": {
     "title": "How do I join?",
-    "body": "Membership is temporarily closed but will be open again soon. Follow us on Twitter for updates!"
+    "body": "To gain access to Developer DAO you can acquire one of our genesis NFTs on the open market or from another DAO member."
   },
   "links": {
     "title": "Useful links",


### PR DESCRIPTION
### What does it do?
As titled

### Any helpful background information?
In https://developerdao.notion.site/Getting-Started-with-Developer-DAO-2bddd332c51a4957b0b83f60f9fa4ebe we see that ddao is open for new members now. Let's update our website accordingly. Ideally this might use inline links to opensea, but i'm not 100% sure how that might play with the translations. So for now let's just update the content to match what's in the notion

to: @with-heart @Dhaiwat10 