### PR TITLE
adding stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,22 @@
+name: 'Stale issue handler'
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@main
+        id: stale
+        with:
+          stale-issue-message:
+            'This issue is stale because it has been open 30 days with no
+            activity. Remove stale label or comment or this will be closed in 15
+            days'
+          days-before-stale: 30
+          days-before-close: 15
+          exempt-issue-labels: 'blocked,must,should,keep'
+      - name: Print outputs
+        run: echo ${{ join(steps.stale.outputs.*, ',') }}


### PR DESCRIPTION
### What does it do?

Add [Github action](https://github.com/actions/stale) to handle stale issues and PRs. After 30 days it leaves a message asking for an update or a comment and if it hears nothing it will close the issue/PR.

@myz1237 what do you think about this? I wonder if we want to auto-close the issues/PRs or if just leaving a message against them is enough for now?

cc @Nazeeh21 @alanpcurrie 

### Any helpful background information?

### Any new dependencies? Why were they added?

Added new action in `stale.yml` but not new deps

### Relevant screenshots/gifs

### Does it close any issues?

Closes #245 
